### PR TITLE
fix: upgrade ramda from 0.26.1 to 0.32.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "author": "Vedad Sose <vedadsose@gmail.com>",
   "dependencies": {
     "argparse": "^1.0.10",
-    "ramda": "^0.26.1"
+    "ramda": "^0.32.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,10 @@ argparse@^1.0.10:
   dependencies:
     sprintf-js "~1.0.2"
 
-ramda@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
+ramda@^0.32.0:
+  version "0.32.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.32.0.tgz#b2116807b59b6b177af7a2ad19b14a3653570e96"
+  integrity sha512-GQWAHhxhxWBWA8oIBr1XahFVjQ9Fic6MK9ikijfd4TZHfE2+urfk+irVlR5VOn48uwMgM+loRRBJd6Yjsbc0zQ==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Security information
Factors contributing to the scoring:
Snyk: [CVSS v3.1 5.3](https://security.snyk.io/vuln/SNYK-JS-RAMDA-1582370) - Medium Severity
NVD: NVD only publishes analysis of vulnerabilities which are assigned a CVE ID. This vulnerability currently does not have an assigned CVE ID.